### PR TITLE
fix(app): keyboard shortcut command conflict

### DIFF
--- a/app/components/tiptap/TiptapProvider.vue
+++ b/app/components/tiptap/TiptapProvider.vue
@@ -4,7 +4,7 @@ import { computed, onMounted, ref, watch } from 'vue'
 import { provideTiptapContext } from '.'
 
 const props = defineProps<{
-  editor: Editor | null
+  editor: Editor | undefined
 }>()
 
 // State management for the Tiptap context

--- a/app/components/tiptap/TiptapToolbar.vue
+++ b/app/components/tiptap/TiptapToolbar.vue
@@ -55,8 +55,7 @@ const wordCount = computed(() => {
     :class="cn(
       'tiptap-toolbar flex flex-wrap gap-1 items-center',
       props.class,
-    )"
-    data-slot="tiptap-toolbar"
+    )" data-slot="tiptap-toolbar"
   >
     <!-- History controls -->
     <div class="flex items-center gap-1">
@@ -64,9 +63,7 @@ const wordCount = computed(() => {
         <Tooltip>
           <TooltipTrigger as-child>
             <Button
-              size="icon"
-              variant="ghost"
-              :disabled="!editor?.can().undo()"
+              size="icon" variant="ghost" :disabled="!editor?.can().undo()"
               @click="editor?.chain().focus().undo().run()"
             >
               <Icon name="mdi:undo" class="h-5 w-5" />
@@ -78,9 +75,7 @@ const wordCount = computed(() => {
         <Tooltip>
           <TooltipTrigger as-child>
             <Button
-              size="icon"
-              variant="ghost"
-              :disabled="!editor?.can().redo()"
+              size="icon" variant="ghost" :disabled="!editor?.can().redo()"
               @click="editor?.chain().focus().redo().run()"
             >
               <Icon name="mdi:redo" class="h-5 w-5" />
@@ -99,10 +94,7 @@ const wordCount = computed(() => {
         <Tooltip>
           <TooltipTrigger as-child>
             <Button
-              size="icon"
-              variant="ghost"
-              :class="{ 'bg-accent': isActive('bold') }"
-              :disabled="!isEditorReady"
+              size="icon" variant="ghost" :class="{ 'bg-accent': isActive('bold') }" :disabled="!isEditorReady"
               @click="editor?.chain().focus().toggleBold().run()"
             >
               <Icon name="mdi:format-bold" class="h-5 w-5" />
@@ -114,10 +106,7 @@ const wordCount = computed(() => {
         <Tooltip>
           <TooltipTrigger as-child>
             <Button
-              size="icon"
-              variant="ghost"
-              :class="{ 'bg-accent': isActive('italic') }"
-              :disabled="!isEditorReady"
+              size="icon" variant="ghost" :class="{ 'bg-accent': isActive('italic') }" :disabled="!isEditorReady"
               @click="editor?.chain().focus().toggleItalic().run()"
             >
               <Icon name="mdi:format-italic" class="h-5 w-5" />
@@ -129,10 +118,7 @@ const wordCount = computed(() => {
         <Tooltip>
           <TooltipTrigger as-child>
             <Button
-              size="icon"
-              variant="ghost"
-              :class="{ 'bg-accent': isActive('strike') }"
-              :disabled="!isEditorReady"
+              size="icon" variant="ghost" :class="{ 'bg-accent': isActive('strike') }" :disabled="!isEditorReady"
               @click="editor?.chain().focus().toggleStrike().run()"
             >
               <Icon name="mdi:format-strikethrough" class="h-5 w-5" />
@@ -144,10 +130,7 @@ const wordCount = computed(() => {
         <Tooltip>
           <TooltipTrigger as-child>
             <Button
-              size="icon"
-              variant="ghost"
-              :class="{ 'bg-accent': isActive('code') }"
-              :disabled="!isEditorReady"
+              size="icon" variant="ghost" :class="{ 'bg-accent': isActive('code') }" :disabled="!isEditorReady"
               @click="editor?.chain().focus().toggleCode().run()"
             >
               <Icon name="mdi:code-tags" class="h-5 w-5" />
@@ -166,11 +149,8 @@ const wordCount = computed(() => {
         <Tooltip>
           <TooltipTrigger as-child>
             <Button
-              size="icon"
-              variant="ghost"
-              :class="{ 'bg-accent': isActive('heading', { level: 1 }) }"
-              :disabled="!isEditorReady"
-              @click="editor?.chain().focus().toggleHeading({ level: 1 }).run()"
+              size="icon" variant="ghost" :class="{ 'bg-accent': isActive('heading', { level: 1 }) }"
+              :disabled="!isEditorReady" @click="editor?.chain().focus().toggleHeading({ level: 1 }).run()"
             >
               <Icon name="mdi:format-header-1" class="h-5 w-5" />
             </Button>
@@ -181,11 +161,8 @@ const wordCount = computed(() => {
         <Tooltip>
           <TooltipTrigger as-child>
             <Button
-              size="icon"
-              variant="ghost"
-              :class="{ 'bg-accent': isActive('heading', { level: 2 }) }"
-              :disabled="!isEditorReady"
-              @click="editor?.chain().focus().toggleHeading({ level: 2 }).run()"
+              size="icon" variant="ghost" :class="{ 'bg-accent': isActive('heading', { level: 2 }) }"
+              :disabled="!isEditorReady" @click="editor?.chain().focus().toggleHeading({ level: 2 }).run()"
             >
               <Icon name="mdi:format-header-2" class="h-5 w-5" />
             </Button>
@@ -196,11 +173,8 @@ const wordCount = computed(() => {
         <Tooltip>
           <TooltipTrigger as-child>
             <Button
-              size="icon"
-              variant="ghost"
-              :class="{ 'bg-accent': isActive('heading', { level: 3 }) }"
-              :disabled="!isEditorReady"
-              @click="editor?.chain().focus().toggleHeading({ level: 3 }).run()"
+              size="icon" variant="ghost" :class="{ 'bg-accent': isActive('heading', { level: 3 }) }"
+              :disabled="!isEditorReady" @click="editor?.chain().focus().toggleHeading({ level: 3 }).run()"
             >
               <Icon name="mdi:format-header-3" class="h-5 w-5" />
             </Button>
@@ -211,11 +185,8 @@ const wordCount = computed(() => {
         <Tooltip>
           <TooltipTrigger as-child>
             <Button
-              size="icon"
-              variant="ghost"
-              :class="{ 'bg-accent': isActive('paragraph') }"
-              :disabled="!isEditorReady"
-              @click="editor?.chain().focus().setParagraph().run()"
+              size="icon" variant="ghost" :class="{ 'bg-accent': isActive('paragraph') }"
+              :disabled="!isEditorReady" @click="editor?.chain().focus().setParagraph().run()"
             >
               <Icon name="mdi:format-paragraph" class="h-5 w-5" />
             </Button>
@@ -233,11 +204,8 @@ const wordCount = computed(() => {
         <Tooltip>
           <TooltipTrigger as-child>
             <Button
-              size="icon"
-              variant="ghost"
-              :class="{ 'bg-accent': isActive('bulletList') }"
-              :disabled="!isEditorReady"
-              @click="editor?.chain().focus().toggleBulletList().run()"
+              size="icon" variant="ghost" :class="{ 'bg-accent': isActive('bulletList') }"
+              :disabled="!isEditorReady" @click="editor?.chain().focus().toggleBulletList().run()"
             >
               <Icon name="mdi:format-list-bulleted" class="h-5 w-5" />
             </Button>
@@ -248,11 +216,8 @@ const wordCount = computed(() => {
         <Tooltip>
           <TooltipTrigger as-child>
             <Button
-              size="icon"
-              variant="ghost"
-              :class="{ 'bg-accent': isActive('orderedList') }"
-              :disabled="!isEditorReady"
-              @click="editor?.chain().focus().toggleOrderedList().run()"
+              size="icon" variant="ghost" :class="{ 'bg-accent': isActive('orderedList') }"
+              :disabled="!isEditorReady" @click="editor?.chain().focus().toggleOrderedList().run()"
             >
               <Icon name="mdi:format-list-numbered" class="h-5 w-5" />
             </Button>
@@ -270,11 +235,8 @@ const wordCount = computed(() => {
         <Tooltip>
           <TooltipTrigger as-child>
             <Button
-              size="icon"
-              variant="ghost"
-              :class="{ 'bg-accent': isActive('blockquote') }"
-              :disabled="!isEditorReady"
-              @click="editor?.chain().focus().toggleBlockquote().run()"
+              size="icon" variant="ghost" :class="{ 'bg-accent': isActive('blockquote') }"
+              :disabled="!isEditorReady" @click="editor?.chain().focus().toggleBlockquote().run()"
             >
               <Icon name="mdi:format-quote-close" class="h-5 w-5" />
             </Button>
@@ -285,9 +247,7 @@ const wordCount = computed(() => {
         <Tooltip>
           <TooltipTrigger as-child>
             <Button
-              size="icon"
-              variant="ghost"
-              :disabled="!isEditorReady"
+              size="icon" variant="ghost" :disabled="!isEditorReady"
               @click="editor?.chain().focus().setHorizontalRule().run()"
             >
               <Icon name="mdi:minus" class="h-5 w-5" />
@@ -299,11 +259,8 @@ const wordCount = computed(() => {
         <Tooltip>
           <TooltipTrigger as-child>
             <Button
-              size="icon"
-              variant="ghost"
-              :class="{ 'bg-accent': isActive('codeBlock') }"
-              :disabled="!isEditorReady"
-              @click="editor?.chain().focus().setCodeBlock().run()"
+              size="icon" variant="ghost" :class="{ 'bg-accent': isActive('codeBlock') }"
+              :disabled="!isEditorReady" @click="editor?.chain().focus().setCodeBlock().run()"
             >
               <Icon name="mdi:code-braces" class="h-5 w-5" />
             </Button>

--- a/app/composables/useSmartShortCut.ts
+++ b/app/composables/useSmartShortCut.ts
@@ -1,0 +1,118 @@
+import type { Ref } from 'vue'
+import { onMounted, onUnmounted, ref } from 'vue'
+
+interface SmartShortcutOptions {
+  // Array of keys that make up the shortcut
+  keys: string[]
+  // CSS selector for the context in which the shortcut should work
+  contextSelector: string
+  // Callback function to run when shortcut is triggered
+  onTrigger: (e: KeyboardEvent) => void
+  // Whether to prevent default browser behavior
+  preventDefault?: boolean
+}
+
+/**
+ * Prevents conflicts with other global shortcuts
+ */
+export function useSmartShortcut(options: SmartShortcutOptions): { keysPressed: Ref<Set<string>> } {
+  const {
+    keys,
+    contextSelector,
+    onTrigger,
+    preventDefault = true,
+  } = options
+
+  const keysPressed = ref<Set<string>>(new Set())
+
+  // Normalize keys to handle different naming conventions
+  const normalizeKey = (key: string): string => {
+    const keyMap: Record<string, string> = {
+      Ctrl: 'Control',
+      Cmd: 'Meta',
+      Alt: 'Alt',
+      Shift: 'Shift',
+    }
+    return keyMap[key] || key
+  }
+
+  const normalizedKeys = keys.map(key =>
+    typeof key === 'string' ? normalizeKey(key.charAt(0).toUpperCase() + key.slice(1).toLowerCase()) : key,
+  )
+
+  // We need to capture events in the capture phase, before they reach any other handlers
+  const handleKeyDown = (e: KeyboardEvent): boolean | undefined => {
+    // Add the pressed key to the set
+    const key = e.key === ' ' ? 'Space' : e.key
+    keysPressed.value.add(e.key.length === 1 ? e.key.toLowerCase() : key)
+
+    // Special handling for modifier keys
+    if (e.ctrlKey)
+      keysPressed.value.add('Control')
+    if (e.metaKey)
+      keysPressed.value.add('Meta')
+    if (e.altKey)
+      keysPressed.value.add('Alt')
+    if (e.shiftKey)
+      keysPressed.value.add('Shift')
+
+    // Check if all required keys are pressed
+    const allKeysPressed = normalizedKeys.every(k =>
+      keysPressed.value.has(k)
+      || (k.length === 1 && keysPressed.value.has(k.toLowerCase())),
+    )
+
+    if (allKeysPressed) {
+      // Check if the target or any of its parents match our selector
+      const targetElement = e.target as HTMLElement
+      const isInContext = targetElement.closest(contextSelector) !== null
+
+      if (isInContext) {
+        // Prevent event from bubbling up to other handlers and prevent default
+        e.stopPropagation()
+        if (preventDefault)
+          e.preventDefault()
+
+        // Execute our callback
+        onTrigger(e)
+
+        // We need to completely halt the event here
+        return false
+      }
+    }
+
+    return undefined
+  }
+
+  const handleKeyUp = (e: KeyboardEvent): void => {
+    const key = e.key === ' ' ? 'Space' : e.key
+    keysPressed.value.delete(e.key.length === 1 ? e.key.toLowerCase() : key)
+
+    // Handle modifier keys release
+    if (!e.ctrlKey)
+      keysPressed.value.delete('Control')
+    if (!e.metaKey)
+      keysPressed.value.delete('Meta')
+    if (!e.altKey)
+      keysPressed.value.delete('Alt')
+    if (!e.shiftKey)
+      keysPressed.value.delete('Shift')
+  }
+
+  onMounted(() => {
+    // Use the capture phase (true as third parameter) to intercept events before they reach other handlers
+    document.addEventListener('keydown', handleKeyDown, true)
+    document.addEventListener('keyup', handleKeyUp, true)
+    window.addEventListener('blur', () => keysPressed.value.clear())
+  })
+
+  onUnmounted(() => {
+    document.removeEventListener('keydown', handleKeyDown, true)
+    document.removeEventListener('keyup', handleKeyUp, true)
+    window.removeEventListener('blur', () => keysPressed.value.clear())
+  })
+
+  return {
+    keysPressed,
+  }
+};

--- a/app/layouts/tiptap-layout.vue
+++ b/app/layouts/tiptap-layout.vue
@@ -14,6 +14,7 @@ import {
   SidebarProvider,
   SidebarTrigger,
 } from '@/components/ui/sidebar'
+import { useSmartShortcut } from '@/composables/useSmartShortCut'
 import CharacterCount from '@tiptap/extension-character-count'
 import Link from '@tiptap/extension-link'
 import Placeholder from '@tiptap/extension-placeholder'
@@ -49,6 +50,28 @@ onBeforeUnmount(() => {
   if (tiptapEditor.value) {
     tiptapEditor.value.destroy()
   }
+})
+
+useSmartShortcut({
+  keys: ['Meta', 'b'], // MacOS
+  contextSelector: '.tiptap-editor-content',
+  onTrigger: () => {
+    if (tiptapEditor.value?.chain().focus()) {
+      tiptapEditor.value.chain().focus().toggleBold().run()
+    }
+  },
+  preventDefault: true,
+})
+
+useSmartShortcut({
+  keys: ['Control', 'b'], // Window / Linux
+  contextSelector: '.tiptap-editor-content',
+  onTrigger: () => {
+    if (tiptapEditor.value?.chain().focus()) {
+      tiptapEditor.value.chain().focus().toggleBold().run()
+    }
+  },
+  preventDefault: true,
 })
 
 // Navigation items

--- a/app/pages/tiptap.vue
+++ b/app/pages/tiptap.vue
@@ -22,7 +22,7 @@ const isMobile = useMediaQuery('(max-width: 768px)')
     </div>
 
     <!-- Editor Content Area -->
-    <div class="flex-1 overflow-auto">
+    <div class="flex-1 overflow-auto tiptap-editor-content">
       <TiptapContent placeholder="Start writing..." />
     </div>
 


### PR DESCRIPTION
This pull request is intended to fix the keyboard shortcut command conflict between Tiptap editor's ( Cmd + b for bold ) and Shadcn's Sidebar ( Cmd + b for collapsing the sidebar ) by creating a new composable named `useSmartShortCut` that enables us to define keyboard shortcuts in a context aware manner that doesn't affect nor trigger keyboard shortcuts that share the same keys and that are defined in a global context.

### So how does it work?

When you focus on Tiptap editor's content area and press `Cmd + b` the letter `B` is toggled and un-toggled. When you move away from the editor ( un-focus ) and press `Cmd + b`, the sidebar is collapsed.



Closes: #12 